### PR TITLE
Fix documentation of HISTIGNORE

### DIFF
--- a/doc/bash.1
+++ b/doc/bash.1
@@ -2300,8 +2300,8 @@ The shell sets the default value to the value of \fBHISTSIZE\fP
 after reading any startup files.
 .TP
 .B HISTIGNORE
-A colon-separated list of patterns used to decide which command lines
-should be saved on the history list.  Each pattern is anchored at the
+A colon-separated list of patterns used to define which command lines
+should not be saved on the history list.  Each pattern is anchored at the
 beginning of the line and must match the complete line (no implicit
 `\fB*\fP' is appended).  Each pattern is tested against the line
 after the checks specified by


### PR DESCRIPTION
Patterns in HISTIGNORE result in commands matching these patterns _not_ to be saved on the history list. (as one would expect from the name of the variable)

Therefore, the current text `list of patterns used to decide which command lines should be saved on the history list.`, while not strictly/logically wrong, is vague and misleading.